### PR TITLE
feat: Refresh launch preview and route CTAs to the app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ NUXT_PUBLIC_SCRIPTS_UMAMI_ANALYTICS_SCRIPT_INPUT_SRC=https://umami.is
 NUXT_PUBLIC_SCRIPTS_UMAMI_ANALYTICS_WEBSITE_ID=
 
 NUXT_SITE_URL=
+NUXT_PUBLIC_LIBROO_APP_URL=https://app.libroo.app
 
 # Optional legal page configuration. Redirect URLs take precedence over markdown URLs.
 # Markdown URLs can point to public R2/S3 objects, GitHub raw files, or a Worker endpoint backed by KV/R2.

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -8,6 +8,8 @@
 }
 
 :root {
+  --ui-radius: 0rem;
+
   --color-royal-blue-50: #f2f5fc;
   --color-royal-blue-100: #e1e8f8;
   --color-royal-blue-200: #cbd8f2;

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -47,6 +47,7 @@ function onClick() {
         color="neutral"
         to="https://github.com/niklhut/libroo"
         target="_blank"
+        rel="noopener noreferrer"
         aria-label="Libroo on GitHub"
         @click="onClick"
       />

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -47,6 +47,7 @@ function onClick() {
         color="neutral"
         to="https://github.com/niklhut/libroo"
         target="_blank"
+        aria-label="Libroo on GitHub"
         @click="onClick"
       />
     </template>

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -56,6 +56,7 @@ const trackHeaderClick = (label: string) => {
       <UButton
         :to="loginUrl"
         target="_blank"
+        rel="noopener noreferrer"
         icon="i-lucide-log-in"
         variant="subtle"
         class="hidden lg:inline-flex"
@@ -75,6 +76,7 @@ const trackHeaderClick = (label: string) => {
         class="mt-4"
         :to="loginUrl"
         target="_blank"
+        rel="noopener noreferrer"
         label="Log in"
         icon="i-lucide-log-in"
         variant="subtle"
@@ -85,6 +87,7 @@ const trackHeaderClick = (label: string) => {
         class="mt-2"
         :to="appUrl"
         target="_blank"
+        rel="noopener noreferrer"
         label="Open app"
         icon="i-lucide-library"
         color="neutral"

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
 const nuxtApp = useNuxtApp()
 const { activeHeadings, updateHeadings } = useScrollspy()
+const { proxy } = useScriptUmamiAnalytics()
+const runtimeConfig = useRuntimeConfig()
+const appUrl = String(runtimeConfig.public.librooAppUrl || 'https://app.libroo.app').replace(/\/$/, '')
+const loginUrl = `${appUrl}/login`
 
 const items = computed(() => [{
   label: 'Features',
   to: '#features',
-  active: activeHeadings.value.includes('features') && !activeHeadings.value.includes('pricing')
+  active: activeHeadings.value.includes('features') && !activeHeadings.value.includes('pricing'),
+  onclick: () => trackHeaderClick('Features')
 }])
 
 nuxtApp.hooks.hookOnce('page:finish', () => {
@@ -14,12 +19,22 @@ nuxtApp.hooks.hookOnce('page:finish', () => {
     document.querySelector('#notify')
   ].filter(Boolean) as Element[])
 })
+
+const trackHeaderClick = (label: string) => {
+  proxy.track('nav_click', {
+    source: 'header',
+    label
+  })
+}
 </script>
 
 <template>
   <UHeader>
     <template #left>
-      <NuxtLink to="/">
+      <NuxtLink
+        to="/"
+        aria-label="Libroo home"
+      >
         <NuxtImg
           src="/Libroo_Icon_Text.png"
           alt="Libroo"
@@ -37,6 +52,17 @@ nuxtApp.hooks.hookOnce('page:finish', () => {
       />
 
       <CustomColorModeButton />
+
+      <UButton
+        :to="loginUrl"
+        target="_blank"
+        icon="i-lucide-log-in"
+        variant="subtle"
+        class="hidden lg:inline-flex"
+        @click="trackHeaderClick('Log in')"
+      >
+        Log in
+      </UButton>
     </template>
 
     <template #body>
@@ -47,9 +73,24 @@ nuxtApp.hooks.hookOnce('page:finish', () => {
       />
       <UButton
         class="mt-4"
-        label="Download App"
+        :to="loginUrl"
+        target="_blank"
+        label="Log in"
+        icon="i-lucide-log-in"
         variant="subtle"
         block
+        @click="trackHeaderClick('Log in')"
+      />
+      <UButton
+        class="mt-2"
+        :to="appUrl"
+        target="_blank"
+        label="Open app"
+        icon="i-lucide-library"
+        color="neutral"
+        variant="ghost"
+        block
+        @click="trackHeaderClick('Open app')"
       />
     </template>
   </UHeader>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -40,8 +40,8 @@ const resolveAppLink = <T extends PageLink>(link: T) => {
   }
 }
 
-const heroLinks = computed(() => page.value?.hero.links.map(resolveAppLink) ?? [])
-const ctaLinks = computed(() => page.value?.cta.links.map(resolveAppLink) ?? [])
+const heroLinks = computed(() => page.value?.hero?.links?.map(resolveAppLink) ?? [])
+const ctaLinks = computed(() => page.value?.cta?.links?.map(resolveAppLink) ?? [])
 
 const handleClick = (link: { label: string }, source: 'hero' | 'cta') => {
   proxy.track('cta_click', {
@@ -60,7 +60,7 @@ const handleClick = (link: { label: string }, source: 'hero' | 'cta') => {
       <UColorModeImage
         light="/images/light/line-1.svg"
         dark="/images/dark/line-1.svg"
-        class="absolute pointer-events-none pb-10 left-0 top-0 object-cover h-162.5"
+        class="absolute pointer-events-none pb-10 left-0 top-12 object-cover h-162.5"
       />
     </div>
 
@@ -69,6 +69,20 @@ const handleClick = (link: { label: string }, source: 'hero' | 'cta') => {
       :links="heroLinks"
       :ui="{ container: 'md:pt-18 lg:pt-20' }"
     >
+      <template
+        v-if="page.hero.badge"
+        #headline
+      >
+        <UBadge
+          :icon="page.hero.badge.icon"
+          color="neutral"
+          variant="subtle"
+          size="lg"
+        >
+          {{ page.hero.badge.label }}
+        </UBadge>
+      </template>
+
       <template #title>
         <MDC
           :value="page.title"
@@ -147,7 +161,9 @@ const handleClick = (link: { label: string }, source: 'hero' | 'cta') => {
 
     <UPageCTA
       id="notify"
-      v-bind="page.cta"
+      :title="page.cta.title"
+      :description="page.cta.description"
+      :links="ctaLinks"
       variant="naked"
       class="overflow-hidden @container"
     >
@@ -165,6 +181,18 @@ const handleClick = (link: { label: string }, source: 'hero' | 'cta') => {
             dark="/images/dark/line-7.svg"
             class="absolute right-0 bottom-0 h-full"
           />
+        </div>
+      </template>
+
+      <template #description>
+        <div class="space-y-3">
+          <p>{{ page.cta.description }}</p>
+          <p
+            v-if="page.cta.note"
+            class="text-sm text-muted"
+          >
+            {{ page.cta.note }}
+          </p>
         </div>
       </template>
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import WaitlistModal from '~/components/WaitlistModal.vue'
-
 const { data: page } = await useAsyncData('index', () => queryCollection('content').first())
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
@@ -19,18 +17,37 @@ useSeoMeta({
   ogDescription: page.value.seo?.description || page.value.description
 })
 
-const overlay = useOverlay()
 const { proxy } = useScriptUmamiAnalytics()
-const modal = overlay.create(WaitlistModal)
+const runtimeConfig = useRuntimeConfig()
+const appUrl = computed(() => String(runtimeConfig.public.librooAppUrl || 'https://app.libroo.app').replace(/\/$/, ''))
 
-const handleClick = (link: { label: string }) => {
-  if (link.label === 'Notify Me') {
-    modal.open({
-      title: page.value?.waitlistModal.title ?? '',
-      description: page.value?.waitlistModal.description ?? ''
-    })
+type PageLink = {
+  label: string
+  appPath?: string
+  to?: string
+}
+
+const resolveAppLink = <T extends PageLink>(link: T) => {
+  const { appPath, ...buttonLink } = link
+
+  if (!appPath) {
+    return buttonLink
   }
-  proxy.track('hero', { name: String(link.label) })
+
+  return {
+    ...buttonLink,
+    to: `${appUrl.value}${appPath.startsWith('/') ? appPath : `/${appPath}`}`
+  }
+}
+
+const heroLinks = computed(() => page.value?.hero.links.map(resolveAppLink) ?? [])
+const ctaLinks = computed(() => page.value?.cta.links.map(resolveAppLink) ?? [])
+
+const handleClick = (link: { label: string }, source: 'hero' | 'cta') => {
+  proxy.track('cta_click', {
+    source,
+    label: String(link.label)
+  })
 }
 </script>
 
@@ -49,7 +66,7 @@ const handleClick = (link: { label: string }) => {
 
     <UPageHero
       :description="page.description"
-      :links="page.hero.links"
+      :links="heroLinks"
       :ui="{ container: 'md:pt-18 lg:pt-20' }"
     >
       <template #title>
@@ -61,10 +78,10 @@ const handleClick = (link: { label: string }) => {
 
       <template #links>
         <UButton
-          v-for="(link, index) in page.hero.links"
+          v-for="(link, index) in heroLinks"
           :key="index"
           v-bind="link"
-          @click="handleClick(link)"
+          @click="handleClick(link, 'hero')"
         />
       </template>
     </UPageHero>
@@ -153,10 +170,10 @@ const handleClick = (link: { label: string }) => {
 
       <template #links>
         <UButton
-          v-for="(link, index) in page.cta.links"
+          v-for="(link, index) in ctaLinks"
           :key="index"
           v-bind="link"
-          @click="handleClick(link)"
+          @click="handleClick(link, 'cta')"
         />
       </template>
 

--- a/content.config.ts
+++ b/content.config.ts
@@ -17,6 +17,8 @@ const createLinkSchema = () => z.object({
   target: createEnum(['_blank', '_self']).optional(),
   color: createEnum(['primary', 'secondary', 'neutral', 'error', 'warning', 'success', 'info']).optional(),
   variant: createEnum(['solid', 'outline', 'subtle', 'soft', 'ghost', 'link']).optional()
+}).refine(link => Boolean(link.to || link.appPath), {
+  message: 'Either "to" or "appPath" must be provided'
 })
 
 const createFeatureSchema = () => createBaseSchema().extend({
@@ -52,8 +54,7 @@ export const collections = {
       }),
       cta: createBaseSchema().extend({
         links: z.array(createLinkSchema())
-      }),
-      waitlistModal: createBaseSchema().optional()
+      })
     })
   })
 }

--- a/content.config.ts
+++ b/content.config.ts
@@ -34,6 +34,10 @@ export const collections = {
     type: 'page',
     schema: z.object({
       hero: z.object({
+        badge: z.object({
+          label: z.string().nonempty(),
+          icon: z.string().optional().editor({ input: 'icon' })
+        }).optional(),
         links: z.array(createLinkSchema())
       }),
       section: createBaseSchema().extend({
@@ -53,6 +57,7 @@ export const collections = {
         features: z.array(createFeatureSchema())
       }),
       cta: createBaseSchema().extend({
+        note: z.string().optional(),
         links: z.array(createLinkSchema())
       })
     })

--- a/content.config.ts
+++ b/content.config.ts
@@ -9,13 +9,14 @@ const createBaseSchema = () => z.object({
 
 const createLinkSchema = () => z.object({
   label: z.string().nonempty(),
-  to: z.string().nonempty(),
+  to: z.string().nonempty().optional(),
+  appPath: z.string().nonempty().optional(),
   icon: z.string().optional().editor({ input: 'icon' }),
-  size: createEnum(['xs', 'sm', 'md', 'lg', 'xl']),
+  size: createEnum(['xs', 'sm', 'md', 'lg', 'xl']).optional(),
   trailing: z.boolean().optional(),
-  target: createEnum(['_blank', '_self']),
-  color: createEnum(['primary', 'secondary', 'neutral', 'error', 'warning', 'success', 'info']),
-  variant: createEnum(['solid', 'outline', 'subtle', 'soft', 'ghost', 'link'])
+  target: createEnum(['_blank', '_self']).optional(),
+  color: createEnum(['primary', 'secondary', 'neutral', 'error', 'warning', 'success', 'info']).optional(),
+  variant: createEnum(['solid', 'outline', 'subtle', 'soft', 'ghost', 'link']).optional()
 })
 
 const createFeatureSchema = () => createBaseSchema().extend({
@@ -41,53 +42,18 @@ export const collections = {
         }),
         features: z.array(
           createBaseSchema().extend({
-            icon: z.string().editor({ input: 'icon' })
+            icon: z.string().editor({ input: 'icon' }).optional(),
+            class: z.string().optional()
           })
         )
       }),
       features: createBaseSchema().extend({
         features: z.array(createFeatureSchema())
       }),
-      steps: createBaseSchema().extend({
-        items: z.array(createFeatureSchema().extend({
-          image: z.object({
-            light: z.string().editor({ input: 'media' }),
-            dark: z.string().editor({ input: 'media' })
-          }).optional()
-        }))
-      }),
-      pricing: createBaseSchema().extend({
-        plans: z.array(
-          createBaseSchema().extend({
-            price: z.string().nonempty(),
-            button: createLinkSchema(),
-            features: z.array(z.string().nonempty()),
-            highlight: z.boolean().optional(),
-            billing_period: z.string().nonempty(),
-            billing_cycle: z.string().nonempty()
-          })
-        )
-      }),
-      testimonials: createBaseSchema().extend({
-        items: z.array(
-          z.object({
-            quote: z.string().nonempty(),
-            user: z.object({
-              name: z.string().nonempty(),
-              description: z.string().nonempty(),
-              to: z.string().nonempty(),
-              avatar: z.object({
-                src: z.string().editor({ input: 'media' }),
-                alt: z.string().optional()
-              }),
-              target: createEnum(['_blank', '_self'])
-            })
-          }))
-      }),
       cta: createBaseSchema().extend({
         links: z.array(createLinkSchema())
       }),
-      waitlistModal: createBaseSchema()
+      waitlistModal: createBaseSchema().optional()
     })
   })
 }

--- a/content/index.yml
+++ b/content/index.yml
@@ -1,12 +1,25 @@
 seo:
-  title: Libroo – Your Personal Library Organizer
-  description: Track books, manage collections, and remember who you’ve lent them to — with Libroo.
+  title: Libroo – Private Library Management for Real Bookshelves
+  description: Catalog books, map shelf locations, track reading progress, manage loans, and run your own private library with Libroo.
 
-title: 📚 Your personal library, [organized]{.text-primary}
-description: Libroo helps you track books you own, manage collections, and keep tabs on loans — all in one simple, open source app.
+title: Your physical library, [under control]{.text-primary}
+description: Libroo is a private, open source library manager for home collections and small libraries. Catalog books, organize shelves, track loans, and keep each book easy to find.
 
 hero:
   links:
+    - label: Log in
+      icon: i-lucide-log-in
+      trailing: true
+      variant: solid
+      size: xl
+      appPath: /login
+      target: _blank
+    - label: Open app
+      icon: i-lucide-library
+      variant: subtle
+      size: xl
+      appPath: /
+      target: _blank
     - label: GitHub
       icon: i-simple-icons-github
       size: xl
@@ -14,62 +27,74 @@ hero:
       variant: ghost
       to: https://github.com/niklhut/libroo
       target: _blank
-    - label: Notify Me
-      icon: i-lucide-mail
-      trailing: true
-      variant: subtle
-      size: xl
 
 section:
-  title: '[Take control]{.text-primary} of your bookshelf'
-  description: Libroo brings clarity to your reading life. Whether you lend books to friends or simply want to track what’s on your shelves, it’s designed to stay out of your way and do the job.
+  title: '[Built for shelves, rooms, boxes, and borrowers]{.text-primary}'
+  description: Libroo models the way physical libraries actually work. Add books quickly, place them in real locations, record the details that matter, and see what is home, borrowed, or missing at a glance.
   images:
     mobile: '/images/bookshelves.svg'
     desktop: '/images/bookshelves.svg'
   features:
-    - title: Track your library
-      description: Add and organize all your books with metadata pulled from Open Library. Keep your digital shelf in sync with your real one.
+    - title: Fast cataloging
+      description: Look up books by ISBN, scan barcodes with your camera, paste bulk ISBN lists, import CSV files, or enter books manually when metadata is not available.
       class: border-l border-primary pl-4
-    - title: Lending made simple
-      description: Never forget who borrowed your book. Record and manage loans with one click.
+    - title: Physical locations
+      description: Create nested locations for rooms, shelves, boxes, or carts, then filter and sort your catalog by exactly where each book lives.
       class: border-l border-default pt-4 pl-4
-    - title: Lightweight and local-first
-      description: Libroo is built for privacy and simplicity. Your data stays yours.
+    - title: Private by design
+      description: Run Libroo as your own private instance, invite only the people who need access, and keep your library data under your control.
       class: border-l border-default pt-4 pl-4
 
 features:
-  title: Everything you need to [track your books]{.text-primary}
-  description: Libroo focuses on the essentials — clean, simple features that make organizing books a joy.
+  title: Everything you need to [run a small library]{.text-primary}
+  description: Libroo is ready for everyday cataloging, lending, administration, and self-hosted operation.
   features:
-    - title: Smart book lookup
-      description: Instantly fetch book details using the Open Library API.
-      icon: i-lucide-search
-    - title: Collection management
-      description: Group your books into collections like “To Read”, “Favorites”, or custom categories.
-      icon: i-lucide-layers
+    - title: ISBN lookup and scanning
+      description: Fetch book details from Open Library, scan barcodes from a phone or laptop camera, and review bulk scan results before adding them.
+      icon: i-lucide-scan-barcode
+    - title: Rich book records
+      description: Store authors, cover images, tags, notes, ratings, reading status, reading progress, and custom location data for every title.
+      icon: i-lucide-book-open-check
+    - title: Search and filters
+      description: Find books by title, author, tag, loan state, reading state, location, or location descendants, with useful sorting for real shelf work.
+      icon: i-lucide-list-filter
     - title: Loan tracking
-      description: Keep track of who borrowed what — and when it’s due back.
-      icon: i-lucide-user-check
-    - title: Clean, responsive UI
-      description: Built with Nuxt UI for a fast, elegant interface on desktop and mobile.
-      icon: i-lucide-layout-dashboard
-    - title: Open source & AGPL
-      description: Libroo is free and open under the AGPL license. Contribute or self-host easily.
-      icon: i-lucide-github
-    - title: Built with modern tools
-      description: Uses Nuxt 3, Drizzle ORM, Postgres, and Vue 3 — production-grade from day one.
-      icon: i-lucide-cpu
+      description: Record books you loan out, mark returns, and share borrower invite links so people can see what has been lent to them.
+      icon: i-lucide-handshake
+    - title: Import and export
+      description: Move library data in and out with CSV import and export workflows, useful for first setup, backups, and migrations.
+      icon: i-lucide-file-spreadsheet
+    - title: Admin controls
+      description: Manage registration, invites, roles, bans, audit logs, email verification, password reset, and first-admin setup from the app.
+      icon: i-lucide-shield-check
+    - title: Email workflows
+      description: Send invites, verification emails, password resets, and security notifications through SMTP or Plunk when your instance needs them.
+      icon: i-lucide-mail-check
+    - title: Self-host or deploy
+      description: Run Libroo with Docker and SQLite-compatible storage, or deploy the hosted Cloudflare/NuxtHub profile with D1 and blob storage.
+      icon: i-lucide-server
+    - title: Open source AGPL
+      description: Libroo is free software under the AGPL, built with Nuxt, Better Auth, Drizzle, Effect, and SQLite-compatible storage.
+      icon: i-simple-icons-github
 
 cta:
-  title: Want to try Libroo when it's ready?
-  description: Enter your email and be the first to know when Libroo is available.
+  title: Ready to open your library?
+  description: Sign in to the hosted app, or use the source code and deployment docs to run Libroo for your own collection.
   links:
-    - label: Notify Me
-      to: '#notify'
-      icon: i-lucide-mail
+    - label: Log in
+      appPath: /login
+      target: _blank
+      icon: i-lucide-log-in
+      variant: solid
+      size: xl
+    - label: View source
+      to: https://github.com/niklhut/libroo
+      target: _blank
+      icon: i-simple-icons-github
+      color: neutral
       variant: subtle
       size: xl
 
 waitlistModal:
-  title: Want to try Libroo when it's ready?
-  description: Enter your email and be the first to know when Libroo is available. We won't spam you, we promise.
+  title: Get Libroo updates
+  description: Enter your email and be the first to know about new Libroo releases. We won't spam you, we promise.

--- a/content/index.yml
+++ b/content/index.yml
@@ -6,6 +6,9 @@ title: Your physical library, [under control]{.text-primary}
 description: Libroo is a private, open source library manager for home collections and small libraries. Catalog books, organize shelves, track loans, and keep each book easy to find.
 
 hero:
+  badge:
+    label: Early release
+    icon: i-lucide-sparkles
   links:
     - label: Log in
       icon: i-lucide-log-in
@@ -80,6 +83,7 @@ features:
 cta:
   title: Ready to open your library?
   description: Sign in to the hosted app, or use the source code and deployment docs to run Libroo for your own collection.
+  note: 'Early release: usable today, with active work on smoother hosting, richer library workflows, and day-to-day polish.'
   links:
     - label: Log in
       appPath: /login

--- a/content/index.yml
+++ b/content/index.yml
@@ -94,7 +94,3 @@ cta:
       color: neutral
       variant: subtle
       size: xl
-
-waitlistModal:
-  title: Get Libroo updates
-  description: Enter your email and be the first to know about new Libroo releases. We won't spam you, we promise.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -87,7 +87,7 @@ export default defineNuxtConfig({
   site: {
     url: process.env.NUXT_SITE_URL || 'https://libroo.app',
     name: 'Libroo',
-    description: 'Libroo helps you track books you own, manage collections, and keep tabs on loans — all in one simple, open source app.',
+    description: 'Libroo is a private, open source library manager for home collections and small libraries.',
     logo: '/favicon-96x96.png'
   },
 
@@ -114,6 +114,7 @@ export default defineNuxtConfig({
       secretKey: ''
     },
     public: {
+      librooAppUrl: process.env.NUXT_PUBLIC_LIBROO_APP_URL || 'https://app.libroo.app',
       scripts: {
         umamiAnalytics: {
           scriptInput: {
@@ -156,6 +157,7 @@ export default defineNuxtConfig({
         ],
         vars: {
           NUXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NUXT_PUBLIC_TURNSTILE_SITE_KEY,
+          NUXT_PUBLIC_LIBROO_APP_URL: process.env.NUXT_PUBLIC_LIBROO_APP_URL || 'https://app.libroo.app',
           NUXT_SITE_URL: process.env.NUXT_SITE_URL,
           NUXT_PUBLIC_SCRIPTS_UMAMI_ANALYTICS_SCRIPT_INPUT_SRC: process.env.NUXT_PUBLIC_SCRIPTS_UMAMI_ANALYTICS_SCRIPT_INPUT_SRC,
           // Use an empty string for optional vars.


### PR DESCRIPTION
## Summary
- Update the landing page copy and content to reflect the current product focus on private library management
- Replace the waitlist-first CTA flow with direct links to log in and open the app
- Add configurable app URL support and track header/CTA clicks with analytics
- Tidy related UI details, including footer accessibility text and a flat global radius token

## Testing
- Not run (not requested)
- Verified the updated page structure and content schema changes are consistent with the new CTA/link model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Log in” and “Open app” buttons/links in the header and updated homepage hero/CTA actions
  * Refreshed hero/CTA rendering from CMS content and centralized CTA click analytics tracking
* **Accessibility**
  * Improved footer GitHub link accessibility with an `aria-label`
* **Style**
  * Added a `--ui-radius` theme variable for consistent corner rounding
* **Documentation**
  * Refreshed homepage marketing content, feature list, and CTAs (including the new badge)
* **Configuration**
  * Added a new Libroo app URL environment/runtime setting; updated content schemas and made related fields optional
<!-- end of auto-generated comment: release notes by coderabbit.ai -->