### PR TITLE
chore: exempt Renovate lockfile maintenance from stability delays

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,5 +7,7 @@ allowBuilds:
   vue-demi: true
   workerd: true
 
+minimumReleaseAge: 1500
+
 overrides:
   h3: 1.15.11

--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,21 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "packageRules": [{
-    "matchDepTypes": ["resolutions"],
-    "enabled": false
-  }],
+  "packageRules": [
+    {
+      "matchDepTypes": ["resolutions"],
+      "enabled": false
+    },
+    {
+      "description": "Lock file maintenance has no single release timestamp, so minimumReleaseAge can leave its status check pending forever.",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "Initial digest pinning has no release timestamp to age-gate; keep minimumReleaseAge for later version updates.",
+      "matchUpdateTypes": ["pin", "pinDigest"],
+      "minimumReleaseAge": null
+    }
+  ],
   "postUpdateOptions": ["pnpmDedupe"]
 }


### PR DESCRIPTION
## Summary
- enforce a 25-hour package release-age delay during pnpm resolution
- exempt Renovate lockfile maintenance, pin, and digest-pin updates when no release timestamp exists

## Why
The lockfile maintenance PR is permanently pending on `renovate/stability-days`, because that update type has no single package release timestamp to evaluate. This preserves the age gate for normal dependency updates while allowing maintenance PRs to merge.

## Validation
- `pnpm config get minimumReleaseAge` → `1500`
- JSON syntax check and configuration matched against niklhut/libroo#204